### PR TITLE
Scoreboard

### DIFF
--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -14,13 +14,10 @@ class ScoreBoard extends HTMLElement {
 		const style = $('style', this.shadow);
 		style.innerText = `
 			:host {
-				background: red;
-				border-radius: 1em;
-				left: 1vw;
-				position: fixed;
-				top: 1vw;
+				background: white;
+				color: black;
+				padding: 1em;
 				width: 100%;
-				color: white;
 			}
 		`;
 

--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -20,7 +20,7 @@ class ScoreBoard extends HTMLElement {
 				width: 100%;
 			}
 		`;
-
+		$('span', this.shadow).innerText = 'Find these:';
 		this.scoreOutput = $('output', this.shadow);
 	}
 

--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -1,0 +1,47 @@
+import { creappend as $ } from './creappend.js';
+
+class ScoreBoard extends HTMLElement {
+	static get observedAttributes() {
+		return ['score'];
+	}
+
+	constructor() {
+		super();
+		console.log('⏱ constructed ScoreBoard');
+
+		this.shadow = this.attachShadow({ mode: 'open' });
+
+		const style = $('style', this.shadow);
+		style.innerText = `
+			:host {
+				background: red;
+				border-radius: 1em;
+				left: 1vw;
+				position: fixed;
+				top: 1vw;
+				width: 100%;
+				color: white;
+			}
+		`;
+
+		this.scoreOutput = $('output', this.shadow);
+	}
+
+	updateScore(score) {
+		this.scoreOutput.innerText = score || 'wtf';
+	}
+
+	connectedCallback() {
+		console.log('🍍 ScoreBoard connected');
+		this.updateScore(this.getAttribute('score'));
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		console.log(
+			`🍉 scoreboard ${name} changed from ${oldValue} to ${newValue}`,
+		);
+		if (name == 'score') this.updateScore(newValue);
+	}
+}
+
+export default ScoreBoard;

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -2,12 +2,10 @@ import shuffle from 'https://cdn.skypack.dev/shuffle-array';
 
 import { creappend as $ } from './creappend.js';
 
+import ScoreBoard from './scoreboard.js';
+customElements.define('score-board', ScoreBoard);
+
 class Scroller extends HTMLElement {
-
-	/*static get observedAttributes() {
-		return ['foo', 'bar'];
-	}*/
-
 	constructor() {
 		super();
 		console.log('🚧 constructed Scroller');
@@ -53,9 +51,13 @@ class Scroller extends HTMLElement {
 		// create some number of collectible sprites
 		const numberOfCollectibles = numberOfSprites * ratioOfCollectibles;
 		const collectibleKinds = [`🎅`, `🤶`];
+		this.kindTotals = {};
 		for (let i = 0; i < numberOfCollectibles; i++) {
-			sprites.push({ kind: shuffle.pick(collectibleKinds), isCollectible: true});
+			const kind = shuffle.pick(collectibleKinds);
+			sprites.push({ kind: kind, isCollectible: true });
+			this.kindTotals[kind] = (this.kindTotals[kind] || 0) + 1;
 		}
+		console.log('👨‍👩‍👧‍👧 kindTotals: ', this.kindTotals);
 
 		// create some other number of uncollectible sprites
 		const numberOfUncollectibles = numberOfSprites - numberOfCollectibles;
@@ -89,35 +91,35 @@ class Scroller extends HTMLElement {
 			`👼`,
 		];
 		for (let i = 0; i < numberOfUncollectibles; i++) {
-			sprites.push({kind: shuffle.pick(uncollectibleKinds), isCollectible: false});
+			sprites.push({
+				kind: shuffle.pick(uncollectibleKinds),
+				isCollectible: false,
+			});
 		}
 
-		// randomize them and add them to the shadow root
+		// randomize the sprites and add them to the shadow root
 		shuffle(sprites);
 		for (let i = 0, n = sprites.length; i < n; i++) {
 			const el = document.createElement('div');
 			el.innerText = sprites[i].kind;
-			if(sprites[i].isCollectible) {
+			if (sprites[i].isCollectible) {
 				el.addEventListener('click', () => {
 					alert('you found me!');
 				});
 			}
 			this.shadow.appendChild(el);
 		}
+
+		// create a scoreboard
+		this.scoreboard = $('score-board', this.shadow);
+		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
+
 	}
 
 	disconnectedCallback() {
 		console.log('🔌');
 		this.removeEventListener('scroll', this.handleScroll);
 	}
-
-	/*adoptedCallback() {
-		console.log('🤱');
-	}*/
-
-	/*attributeChangedCallback(name, oldValue, newValue) {
-		console.log('📶', name, oldValue, newValue);
-	}*/
 }
 
 export default Scroller;

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -15,23 +15,24 @@ class Scroller extends HTMLElement {
 		const style = $('style', this.shadow);
 		style.innerText = `
 			:host {
-				all: initial;
-				background: black;
-				contain: content;
-				display: grid;
-				grid-template-columns: repeat(5, 1fr);
-				height: 100%;
-				left: 0;
+				display: flex;
+				flex-direction: column;
 				position: absolute;
 				top: 0;
+				left: 0;
 				width: 100%;
+				height: 100%;
+			}
+			.container {
+				background: black;
+				display: grid;
+				grid-template-columns: repeat(5, 1fr);
 				overflow: scroll;
 			}
-
-			div {
+			.sprite {
+				font-size: 13vw;
 				justify-self: center;
 				margin: 1vw;
-				font-size: 13vw;
 			}
 		`;
 	}
@@ -97,22 +98,26 @@ class Scroller extends HTMLElement {
 			});
 		}
 
-		// randomize the sprites and add them to the shadow root
+		// create a scoreboard
+		this.scoreboard = $('score-board', this.shadow);
+		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
+
+		// randomize the sprites and add them to a .container
 		shuffle(sprites);
+		const container = $('div', this.shadow);
+		container.className = 'container';
 		for (let i = 0, n = sprites.length; i < n; i++) {
-			const el = document.createElement('div');
+			const el = $('div', container);
 			el.innerText = sprites[i].kind;
+			el.className = 'sprite';
 			if (sprites[i].isCollectible) {
 				el.addEventListener('click', () => {
 					alert('you found me!');
 				});
 			}
-			this.shadow.appendChild(el);
 		}
 
-		// create a scoreboard
-		this.scoreboard = $('score-board', this.shadow);
-		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
+
 
 	}
 

--- a/public/settings.js
+++ b/public/settings.js
@@ -27,6 +27,7 @@ class Settings extends HTMLElement {
 		this.numberOfSprites = 500;
 		this.ratioOfCollectibles = 0.025;
 
+		// cloning the settings form from a template to save the pain of building it piece by piece
 		const formTemplate = document.createElement('template');
 		formTemplate.innerHTML = `<form>
 			<label>
@@ -54,6 +55,7 @@ class Settings extends HTMLElement {
 		</form>`;
 		const formClone = formTemplate.content.cloneNode(true);
 
+		// need to store a reference to this because the formClone seems to go stale
 		this.numberOfSpritesOutput = formClone.getElementById(
 			'numberOfSpritesOutput',
 		);
@@ -68,6 +70,7 @@ class Settings extends HTMLElement {
 			this.numberOfSpritesOutput.innerText = this.numberOfSprites;
 		};
 
+		// need to store a reference to this because the formClone seems to go stale
 		this.ratioOfCollectiblesOutput = formClone.getElementById(
 			'ratioOfCollectiblesOutput',
 		);


### PR DESCRIPTION
This branch adds a box at the top of the screen that shows how many of each collectible is available.  It doesn't currently change, because I'm going to change how that works in #11 

In order to prevent the scoreboard from overlaping and obscuring sprites I had to move the sprites to a container, and layout the scoreboard and scroller with flex.

Currently the component just prints out it's score attribute, but I can JSON parse it and populate different elements later on.