### PR TITLE
Tap to collect

### DIFF
--- a/public/scroller.js
+++ b/public/scroller.js
@@ -34,6 +34,9 @@ class Scroller extends HTMLElement {
 				justify-self: center;
 				margin: 1vw;
 			}
+			.collected {
+				background: red;
+			}
 		`;
 	}
 
@@ -106,19 +109,56 @@ class Scroller extends HTMLElement {
 		shuffle(sprites);
 		const container = $('div', this.shadow);
 		container.className = 'container';
+
+		const intersected = [];
+		const collected = [];
+
+		this.observer = new IntersectionObserver((entries, observer) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					console.log(
+						'👀 collectible came into view',
+						entry.target.innerText,
+					);
+					intersected.push(entry.target);
+				} else {
+					console.log(
+						'🙈 collectible became hidden',
+						entry.target.innerText,
+					);
+					delete intersected[intersected.indexOf(entry.target)];
+				}
+			});
+		});
+
 		for (let i = 0, n = sprites.length; i < n; i++) {
-			const el = $('div', container);
-			el.innerText = sprites[i].kind;
-			el.className = 'sprite';
-			if (sprites[i].isCollectible) {
-				el.addEventListener('click', () => {
+			const sprite = sprites[i];
+			const spriteElement = $('div', container);
+			spriteElement.innerText = sprite.kind;
+			spriteElement.className = 'sprite';
+			if (sprite.isCollectible) {
+				spriteElement.addEventListener('click', () => {
 					alert('you found me!');
 				});
+				this.observer.observe(spriteElement);
 			}
 		}
 
+		// clicking anywhere on the sprite container collects all the collectible sprites in the view port
+		container.onclick = (event) => {
+			for (let sprite of intersected) {
+				if (sprite && !collected.includes(sprite)) {
+					console.log(sprite, typeof sprite);
+					collected.push(sprite);
+					sprite.classList.add('collected');
+				}
+			}
 
-
+			console.log(
+				'📸 collecting all the sprites that intersect the viewport',
+				collected.length,
+			);
+		};
 	}
 
 	disconnectedCallback() {

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -44,6 +44,10 @@ class Scroller extends HTMLElement {
 		console.log('📜', window.scrollY);
 	}
 
+	updateScore() {
+		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
+	}
+
 	connectedCallback() {
 		console.log('🥌 Scroller connected');
 		this.addEventListener('scroll', this.handleScroll);
@@ -103,7 +107,7 @@ class Scroller extends HTMLElement {
 
 		// create a scoreboard
 		this.scoreboard = $('score-board', this.shadow);
-		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
+		this.updateScore();
 
 		// randomize the sprites and add them to a .container
 		shuffle(sprites);
@@ -151,13 +155,12 @@ class Scroller extends HTMLElement {
 					console.log(sprite, typeof sprite);
 					collected.push(sprite);
 					sprite.classList.add('collected');
+					this.kindTotals[sprite.innerText]--;
+					this.updateScore();
 				}
 			}
 
-			console.log(
-				'📸 collecting all the sprites that intersect the viewport',
-				collected.length,
-			);
+			console.log(`📸 collecting ${collected.length}`);
 		};
 	}
 


### PR DESCRIPTION
this branch adds intersection observers to the collectible sprites. When the scroller is clicked all the collectible sprites that are contained in the `intersected` array are given the class "collected" and added to the `collected` array.

Fixes #11 