### PR TITLE
Refactoring to Lit

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
 	"arrowParens": "always",
+	"printWidth": 100,
 	"semi": true,
 	"singleQuote": true,
 	"trailingComma": "all"

--- a/public/creappend.js
+++ b/public/creappend.js
@@ -1,5 +1,0 @@
-export function creappend(tagName, parent) {
-	const element = document.createElement(tagName);
-	parent.appendChild(element);
-	return element;
-}

--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -1,57 +1,45 @@
-import { creappend as $ } from './creappend.js';
+import { LitElement, html, css } from 'https://cdn.skypack.dev/lit-element';
 
-class ScoreBoard extends HTMLElement {
-	static get observedAttributes() {
-		return ['score'];
-	}
-
-	constructor() {
-		super();
-		console.log('⏱ constructed ScoreBoard');
-
-		this.shadow = this.attachShadow({ mode: 'open' });
-
-		const style = $('style', this.shadow);
-		style.innerText = `
+class ScoreBoard extends LitElement {
+	static get styles() {
+		return css`
 			:host {
 				background: black;
 				color: white;
 				display: flex;
 				justify-content: space-around;
-				padding: .5em;
+				padding: 0.5em;
 			}
 		`;
-		$('span', this.shadow).innerText = 'Find these:';
-		this.scoreOutput = $('output', this.shadow);
+	}
 
-		const timer = $('span', this.shadow);
-		timer.id = 'timer';
-		timer.innerText = '00:00';
+	static get properties() {
+		return {
+			score: { type: String },
+			timer: { type: String },
+		};
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
 		this.timerStart = new Date().getTime();
 
 		this.timerInterval = setInterval(() => {
 			const now = new Date().getTime();
 			const distance = now - this.timerStart;
 			const seconds = Math.floor((distance % (1000 * 60)) / 1000) + '';
-			const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)) + '';
-			timer.innerText = `${minutes.padStart(2, 0)}:${seconds.padStart(2, 0)}`;
+			const minutes =
+				Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)) + '';
+			this.timer = `${minutes.padStart(2, 0)}:${seconds.padStart(2, 0)}`;
 		}, 1000);
+
+		console.log('⏱ ScoreBoard connected');
 	}
 
-	updateScore(score) {
-		this.scoreOutput.innerText = score || 'wtf';
-	}
-
-	connectedCallback() {
-		console.log('🍍 ScoreBoard connected');
-		this.updateScore(this.getAttribute('score'));
-	}
-
-	attributeChangedCallback(name, oldValue, newValue) {
-		console.log(
-			`🍉 scoreboard ${name} changed from ${oldValue} to ${newValue}`,
-		);
-		if (name == 'score') this.updateScore(newValue);
+	render() {
+		return html`Find these: <output>${this.score}</output>
+			<span>${this.timer}</span>`;
 	}
 }
 

--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -38,7 +38,7 @@ class ScoreBoard extends LitElement {
 	}
 
 	render() {
-		return html`Find these: <output>${this.score}</output>
+		return html`Find these: <output>${JSON.stringify(this.score)}</output>
 			<span>${this.timer}</span>`;
 	}
 }

--- a/public/scoreboard.js
+++ b/public/scoreboard.js
@@ -29,8 +29,7 @@ class ScoreBoard extends LitElement {
 			const now = new Date().getTime();
 			const distance = now - this.timerStart;
 			const seconds = Math.floor((distance % (1000 * 60)) / 1000) + '';
-			const minutes =
-				Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)) + '';
+			const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)) + '';
 			this.timer = `${minutes.padStart(2, 0)}:${seconds.padStart(2, 0)}`;
 		}, 1000);
 

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -21,12 +21,7 @@ class Scroller extends LitElement {
 				height: 100%;
 			}
 			.container {
-				background-image: linear-gradient(
-					to right top,
-					#d16ba5,
-					#8aa7ec,
-					#5ffbf1
-				);
+				background-image: linear-gradient(to right top, #d16ba5, #8aa7ec, #5ffbf1);
 				display: grid;
 				grid-template-columns: repeat(5, 1fr);
 				overflow: scroll;
@@ -45,16 +40,10 @@ class Scroller extends LitElement {
 	observer = new IntersectionObserver((entries) => {
 		entries.forEach((entry) => {
 			if (entry.isIntersecting) {
-				console.log(
-					'👀 collectible came into view',
-					entry.target.innerText,
-				);
+				console.log('👀 collectible came into view', entry.target.innerText);
 				this.intersected.push(entry.target);
 			} else {
-				console.log(
-					'🙈 collectible became hidden',
-					entry.target.innerText,
-				);
+				console.log('🙈 collectible became hidden', entry.target.innerText);
 				delete this.intersected[this.intersected.indexOf(entry.target)];
 			}
 		});

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -9,6 +9,12 @@ import Sprite from './sprite.js';
 customElements.define('sprite-comp', Sprite);
 
 class Scroller extends LitElement {
+	static get properties() {
+		return {
+			numberOfSprites: { type: String },
+			ratioOfCollectibles: { type: String },
+		};
+	}
 	static get styles() {
 		return css`
 			:host {
@@ -51,12 +57,13 @@ class Scroller extends LitElement {
 
 	connectedCallback() {
 		super.connectedCallback();
+		this.generateSprites();
 		console.log('🥌 Scroller connected');
-		const numberOfSprites = this.getAttribute('numberOfSprites');
-		const ratioOfCollectibles = this.getAttribute('ratioOfCollectibles');
+	}
 
+	generateSprites() {
 		// create some number of collectible sprites
-		const numberOfCollectibles = numberOfSprites * ratioOfCollectibles;
+		const numberOfCollectibles = this.numberOfSprites * this.ratioOfCollectibles;
 		const collectibleKinds = [`🎅`, `🤶`];
 
 		for (let i = 0; i < numberOfCollectibles; i++) {
@@ -67,7 +74,7 @@ class Scroller extends LitElement {
 		console.log('👨‍👩‍👧‍👧 kindTotals: ', this.kindTotals);
 
 		// create some other number of uncollectible sprites
-		const numberOfUncollectibles = numberOfSprites - numberOfCollectibles;
+		const numberOfUncollectibles = this.numberOfSprites - numberOfCollectibles;
 		const uncollectibleKinds = [
 			`👩`,
 			`👨`,
@@ -104,7 +111,6 @@ class Scroller extends LitElement {
 			});
 		}
 
-		// randomize the sprites and add them to a .container
 		shuffle(this.sprites);
 	}
 

--- a/public/scroller.js
+++ b/public/scroller.js
@@ -1,19 +1,16 @@
-import shuffle from 'https://cdn.skypack.dev/shuffle-array';
+import { LitElement, html, css } from 'https://cdn.skypack.dev/lit-element';
 
-import { creappend as $ } from './creappend.js';
+import shuffle from 'https://cdn.skypack.dev/shuffle-array';
 
 import ScoreBoard from './scoreboard.js';
 customElements.define('score-board', ScoreBoard);
 
-class Scroller extends HTMLElement {
-	constructor() {
-		super();
-		console.log('🚧 constructed Scroller');
+import Sprite from './sprite.js';
+customElements.define('sprite-comp', Sprite);
 
-		this.shadow = this.attachShadow({ mode: 'open' });
-
-		const style = $('style', this.shadow);
-		style.innerText = `
+class Scroller extends LitElement {
+	static get styles() {
+		return css`
 			:host {
 				display: flex;
 				flex-direction: column;
@@ -24,45 +21,58 @@ class Scroller extends HTMLElement {
 				height: 100%;
 			}
 			.container {
-				background-image: linear-gradient(to right top, #d16ba5, #c777b9, #ba83ca, #aa8fd8, #9a9ae1, #8aa7ec, #79b3f4, #69bff8, #52cffe, #41dfff, #46eefa, #5ffbf1);
+				background-image: linear-gradient(
+					to right top,
+					#d16ba5,
+					#8aa7ec,
+					#5ffbf1
+				);
 				display: grid;
 				grid-template-columns: repeat(5, 1fr);
 				overflow: scroll;
 			}
-			.sprite {
-				font-size: 13vw;
-				justify-self: center;
-				margin: 1vw;
-			}
 			.collected {
-				background: red;
+				opacity: 0.5;
 			}
 		`;
 	}
 
-	handleScroll() {
-		console.log('📜', window.scrollY);
-	}
+	sprites = [];
+	intersected = [];
+	collected = [];
+	kindTotals = {};
 
-	updateScore() {
-		this.scoreboard.setAttribute('score', JSON.stringify(this.kindTotals));
-	}
+	observer = new IntersectionObserver((entries) => {
+		entries.forEach((entry) => {
+			if (entry.isIntersecting) {
+				console.log(
+					'👀 collectible came into view',
+					entry.target.innerText,
+				);
+				this.intersected.push(entry.target);
+			} else {
+				console.log(
+					'🙈 collectible became hidden',
+					entry.target.innerText,
+				);
+				delete this.intersected[this.intersected.indexOf(entry.target)];
+			}
+		});
+	});
 
 	connectedCallback() {
+		super.connectedCallback();
 		console.log('🥌 Scroller connected');
-		this.addEventListener('scroll', this.handleScroll);
 		const numberOfSprites = this.getAttribute('numberOfSprites');
 		const ratioOfCollectibles = this.getAttribute('ratioOfCollectibles');
-
-		const sprites = [];
 
 		// create some number of collectible sprites
 		const numberOfCollectibles = numberOfSprites * ratioOfCollectibles;
 		const collectibleKinds = [`🎅`, `🤶`];
-		this.kindTotals = {};
+
 		for (let i = 0; i < numberOfCollectibles; i++) {
 			const kind = shuffle.pick(collectibleKinds);
-			sprites.push({ kind: kind, isCollectible: true });
+			this.sprites.push({ kind: kind, isCollectible: true });
 			this.kindTotals[kind] = (this.kindTotals[kind] || 0) + 1;
 		}
 		console.log('👨‍👩‍👧‍👧 kindTotals: ', this.kindTotals);
@@ -99,74 +109,40 @@ class Scroller extends HTMLElement {
 			`👼`,
 		];
 		for (let i = 0; i < numberOfUncollectibles; i++) {
-			sprites.push({
+			this.sprites.push({
 				kind: shuffle.pick(uncollectibleKinds),
 				isCollectible: false,
 			});
 		}
 
-		// create a scoreboard
-		this.scoreboard = $('score-board', this.shadow);
-		this.updateScore();
-
 		// randomize the sprites and add them to a .container
-		shuffle(sprites);
-		const container = $('div', this.shadow);
-		container.className = 'container';
+		shuffle(this.sprites);
+	}
 
-		const intersected = [];
-		const collected = [];
-
-		this.observer = new IntersectionObserver((entries, observer) => {
-			entries.forEach((entry) => {
-				if (entry.isIntersecting) {
-					console.log(
-						'👀 collectible came into view',
-						entry.target.innerText,
-					);
-					intersected.push(entry.target);
-				} else {
-					console.log(
-						'🙈 collectible became hidden',
-						entry.target.innerText,
-					);
-					delete intersected[intersected.indexOf(entry.target)];
-				}
-			});
-		});
-
-		for (let i = 0, n = sprites.length; i < n; i++) {
-			const sprite = sprites[i];
-			const spriteElement = $('div', container);
-			spriteElement.innerText = sprite.kind;
-			spriteElement.className = 'sprite';
-			if (sprite.isCollectible) {
-				spriteElement.addEventListener('click', () => {
-					alert('you found me!');
-				});
-				this.observer.observe(spriteElement);
+	handleClick() {
+		for (let sprite of this.intersected) {
+			if (sprite && !this.collected.includes(sprite)) {
+				this.collected.push(sprite);
+				sprite.classList.add('collected');
+				this.kindTotals[sprite.innerText]--;
 			}
 		}
 
-		// clicking anywhere on the sprite container collects all the collectible sprites in the view port
-		container.onclick = (event) => {
-			for (let sprite of intersected) {
-				if (sprite && !collected.includes(sprite)) {
-					console.log(sprite, typeof sprite);
-					collected.push(sprite);
-					sprite.classList.add('collected');
-					this.kindTotals[sprite.innerText]--;
-					this.updateScore();
-				}
-			}
-
-			console.log(`📸 collecting ${collected.length}`);
-		};
+		console.log(`📸 collecting ${this.collected.length}`);
 	}
 
-	disconnectedCallback() {
-		console.log('🔌');
-		this.removeEventListener('scroll', this.handleScroll);
+	render() {
+		return html`<score-board .score="${this.kindTotals}"></score-board>
+			<div class="container" @click="${this.handleClick}">
+				${this.sprites.map(
+					(sprite) =>
+						html`<sprite-comp
+							.observer="${this.observer}"
+							.isCollectible="${sprite.isCollectible}"
+							>${sprite.kind}</sprite-comp
+						>`,
+				)}
+			</div>`;
 	}
 }
 

--- a/public/settings.js
+++ b/public/settings.js
@@ -1,17 +1,11 @@
-import { creappend as $ } from './creappend.js';
+import { LitElement, html, css } from 'https://cdn.skypack.dev/lit-element';
 
 import Scroller from './scroller.js';
 customElements.define('scroller-modal', Scroller);
 
-class Settings extends HTMLElement {
-	constructor() {
-		super();
-		console.log('💠');
-
-		this.shadow = this.attachShadow({ mode: 'open' });
-
-		const style = $('style', this.shadow);
-		style.innerText = `
+class Settings extends LitElement {
+	static get styles() {
+		return css`
 			form {
 				font-size: 6vw;
 			}
@@ -23,108 +17,88 @@ class Settings extends HTMLElement {
 				display: block;
 			}
 		`;
-
-		this.numberOfSprites = 500;
-		this.ratioOfCollectibles = 0.025;
-
-		// cloning the settings form from a template to save the pain of building it piece by piece
-		const formTemplate = document.createElement('template');
-		formTemplate.innerHTML = `<form>
-			<label>
-				number of sprites
-				<input
-					id="numberOfSprites"
-					type="range"
-					min="10"
-					max="9999"
-					value="${this.numberOfSprites}" />
-				<output id="numberOfSpritesOutput">${this.numberOfSprites}</output>
-			</label>
-			<label>
-				ratio of collectibles
-				<input
-					id="ratioOfCollectibles"
-					type="range"
-					min="0.001"
-					max="0.1"
-					step="0.001"
-					value="${this.ratioOfCollectibles}" />
-				<output id="ratioOfCollectiblesOutput">${this.ratioOfCollectibles}</output>
-			</label>
-			<input type="submit" value="Play!" />
-		</form>`;
-		const formClone = formTemplate.content.cloneNode(true);
-
-		// need to store a reference to this because the formClone seems to go stale
-		this.numberOfSpritesOutput = formClone.getElementById(
-			'numberOfSpritesOutput',
-		);
-
-		formClone.getElementById('numberOfSprites').onchange = (event) => {
-			console.log(
-				`🧚‍♀️ number of sprites changed`,
-				this.numberOfSprites,
-				event.target.value,
-			);
-			this.numberOfSprites = event.target.value;
-			this.numberOfSpritesOutput.innerText = this.numberOfSprites;
-		};
-
-		// need to store a reference to this because the formClone seems to go stale
-		this.ratioOfCollectiblesOutput = formClone.getElementById(
-			'ratioOfCollectiblesOutput',
-		);
-
-		formClone.getElementById('ratioOfCollectibles').onchange = (event) => {
-			console.log(
-				`🧜‍♀️ ratio changed`,
-				this.ratioOfCollectibles,
-				event.target.value,
-			);
-			this.ratioOfCollectibles = event.target.value;
-			this.ratioOfCollectiblesOutput.innerText = this.ratioOfCollectibles;
-		};
-
-		formClone.querySelector('input[type=submit]').onclick = (event) => {
-			console.log('🎲', this.numberOfCollectibles);
-			event.preventDefault();
-
-			const scroller = document.createElement('scroller-modal');
-			scroller.setAttribute('numberOfSprites', this.numberOfSprites);
-			scroller.setAttribute(
-				'ratioOfCollectibles',
-				this.ratioOfCollectibles,
-			);
-			this.shadow.appendChild(scroller);
-			// TODO delete any existing scrollers before adding a new one
-
-			const url = new URL(window.location);
-			url.searchParams.set('numberOfSprites', this.numberOfSprites);
-			url.searchParams.set(
-				'ratioOfCollectibles',
-				this.ratioOfCollectibles,
-			);
-			window.history.pushState({}, '', url);
-
-			return false;
-		};
-
-		this.shadow.appendChild(formClone);
 	}
 
-	popstateHandler(event) {
-		console.log('🍿 state is popping');
-		this.shadow.querySelector('scroller-modal').remove();
-	}
+	numberOfSprites = 500;
+	ratioOfCollectibles = 0.025;
 
 	connectedCallback() {
+		super.connectedCallback();
 		console.log('🧮 Settings Connected');
-		window.addEventListener('popstate', this.popstateHandler.bind(this));
+		window.addEventListener('popstate', this.handlePopstate.bind(this));
 	}
 
 	disconnectedCallback() {
+		super.disconnectedCallback();
 		console.log('🛑 Settings Disconnected');
-		window.removeEventListener('popstate', this.popstateHandler);
+		window.removeEventListener('popstate', this.handlePopstate);
+	}
+
+	handlePopstate() {
+		console.log('🍿 user navigated back');
+		this.isPlaying = false;
+	}
+
+	handleNumberOfSpritesChange(event) {
+		this.numberOfSprites = event.target.value;
+	}
+
+	handleRatioOfCollectiblesChange(event) {
+		this.ratioOfCollectibles = event.target.value;
+	}
+
+	handleSubmit(event) {
+		event.preventDefault();
+		console.log(`🎲 let's play!`);
+
+		this.isPlaying = true;
+		// update the url
+		const url = new URL(window.location);
+		url.searchParams.set('numberOfSprites', this.numberOfSprites);
+		url.searchParams.set('ratioOfCollectibles', this.ratioOfCollectibles);
+		window.history.pushState({}, '', url);
+
+		return false;
+	}
+
+	render() {
+		return html`<form @submit="${this.handleSubmit}">
+				<label>
+					number of sprites
+					<input
+						id="numberOfSprites"
+						type="range"
+						min="10"
+						max="9999"
+						@change="${this.handleNumberOfSpritesChange}"
+						value="${this.numberOfSprites}"
+					/>
+					<output id="numberOfSpritesOutput"
+						>${this.numberOfSprites}</output
+					>
+				</label>
+				<label>
+					ratio of collectibles
+					<input
+						id="ratioOfCollectibles"
+						type="range"
+						min="0.001"
+						max="0.1"
+						step="0.001"
+						@change="${this.handleRatioOfCollectiblesChange}"
+						value="${this.ratioOfCollectibles}"
+					/>
+					<output id="ratioOfCollectiblesOutput"
+						>${this.ratioOfCollectibles}</output
+					>
+				</label>
+				<input type="submit" value="Play!" />
+			</form>
+			${this.isPlaying &&
+			html`<scroller-modal
+				numberOfSprites="${this.numberOfSprites}"
+				ratioOfCollectibles="${this.ratioOfCollectibles}"
+			></scroller-modal>`}`;
 	}
 }
 

--- a/public/settings.js
+++ b/public/settings.js
@@ -19,6 +19,12 @@ class Settings extends LitElement {
 		`;
 	}
 
+	static get properties() {
+		return {
+			isPlaying: { type: Boolean }
+		};
+	}
+
 	numberOfSprites = 500;
 	ratioOfCollectibles = 0.025;
 
@@ -52,6 +58,7 @@ class Settings extends LitElement {
 		console.log(`🎲 let's play!`);
 
 		this.isPlaying = true;
+
 		// update the url
 		const url = new URL(window.location);
 		url.searchParams.set('numberOfSprites', this.numberOfSprites);

--- a/public/settings.js
+++ b/public/settings.js
@@ -73,9 +73,7 @@ class Settings extends LitElement {
 						@change="${this.handleNumberOfSpritesChange}"
 						value="${this.numberOfSprites}"
 					/>
-					<output id="numberOfSpritesOutput"
-						>${this.numberOfSprites}</output
-					>
+					<output id="numberOfSpritesOutput">${this.numberOfSprites}</output>
 				</label>
 				<label>
 					ratio of collectibles
@@ -88,9 +86,7 @@ class Settings extends LitElement {
 						@change="${this.handleRatioOfCollectiblesChange}"
 						value="${this.ratioOfCollectibles}"
 					/>
-					<output id="ratioOfCollectiblesOutput"
-						>${this.ratioOfCollectibles}</output
-					>
+					<output id="ratioOfCollectiblesOutput">${this.ratioOfCollectibles}</output>
 				</label>
 				<input type="submit" value="Play!" />
 			</form>

--- a/public/settings.js
+++ b/public/settings.js
@@ -21,7 +21,7 @@ class Settings extends LitElement {
 
 	static get properties() {
 		return {
-			isPlaying: { type: Boolean }
+			isPlaying: { type: Boolean },
 		};
 	}
 
@@ -97,11 +97,12 @@ class Settings extends LitElement {
 				</label>
 				<input type="submit" value="Play!" />
 			</form>
-			${this.isPlaying &&
-			html`<scroller-modal
-				numberOfSprites="${this.numberOfSprites}"
-				ratioOfCollectibles="${this.ratioOfCollectibles}"
-			></scroller-modal>`}`;
+			${this.isPlaying
+				? html`<scroller-modal
+						numberOfSprites="${this.numberOfSprites}"
+						ratioOfCollectibles="${this.ratioOfCollectibles}"
+				  ></scroller-modal>`
+				: null}`;
 	}
 }
 

--- a/public/sprite.js
+++ b/public/sprite.js
@@ -8,7 +8,6 @@ class Sprite extends LitElement {
 				justify-self: center;
 				margin: 1vw;
 			}
-
 		`;
 	}
 	static get properties() {

--- a/public/sprite.js
+++ b/public/sprite.js
@@ -1,0 +1,37 @@
+import { LitElement, html, css } from 'https://cdn.skypack.dev/lit-element';
+
+class Sprite extends LitElement {
+	static get styles() {
+		return css`
+			:host {
+				font-size: 13vw;
+				justify-self: center;
+				margin: 1vw;
+			}
+
+		`;
+	}
+	static get properties() {
+		return {
+			observer: { type: Object, attribute: false },
+			isCollectible: { type: Boolean },
+			isCollected: { type: Boolean },
+		};
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
+		if (this.isCollectible) {
+			this.observer.observe(this);
+		}
+
+		console.log('👾 sprite connected');
+	}
+
+	render() {
+		return html`<slot>${this.kind}</slot>`;
+	}
+}
+
+export default Sprite;


### PR DESCRIPTION
So far I've just been raw-dogging the DOM Apis by creating a shadowDom, createElement()ing and appendChild()ing. I was even creating my own <style> elements to attach CSS. It got real ugly real fast. It always does. 

The worst part was how difficult it was to pass real JavaScript values from parents to children. I tried to switch complicated parts to use html templates [like I did here ](https://github.com/jessehattabaugh/scroller/blob/86210a107740d5bc059c32fa7bf588eddb405a9e/public/settings.js#L39) and that cleaned things up a little, but it wasn't enough. 

Then I remembered that this is basically the pain that LitElement was created to solve. All the DOM generation code moves to the render(), the styles move to a static property, changes get batched to animationFrame, callbacks get scoped to the component, and best of all I can now pass JS data into child components' object properties!

This really clarifies and untangles the code. Concerns were already creeping into each other, as was made obvious while I was refactoring the Scroller. It was manually creating each sprite and then passing it to the observer to watch for interactions. But when I render all the sprites in a loop I don't have access to their DOMs. So I had to create a new component just for sprites so I could get access to the DOM nodes of each sprite.  In doing so it's made me realize that Sprite logic had creeped into several other places. 